### PR TITLE
fix: apply AWS infrastructure copy update to root index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,8 +206,8 @@
             <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
           </svg>
         </div>
-        <h3>Bank-Grade Security</h3>
-        <p>Your data is encrypted at rest and in transit. Fine-grained access controls keep everything locked down.</p>
+        <h3>Built on AWS</h3>
+        <p>Built on AWS's enterprise-grade infrastructure. Your data is encrypted at rest and in transit, with fine-grained access controls keeping everything locked down.</p>
       </div>
       <div class="feature-card">
         <div class="feature-icon">


### PR DESCRIPTION
## Summary

- Applies the same "Built on AWS" copy change to the root `index.html`, which is the file GitHub Pages actually serves
- The previous PR (#9) only updated `landing-page/index.html`

## References

Follow-up to #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)